### PR TITLE
Inclusao do docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: "3"
+services:
+  wavefront_proxy:
+    image: wavefronthq/proxy:4.31
+    ports:
+      - "2878:2878"
+      - "4242:4242"
+    environment:
+      WAVEFRONT_URL: ${WAVEFRONT_URL}
+      WAVEFRONT_TOKEN: ${WAVEFRONT_TOKEN}
+      JAVA_HEAP_USAGE: 512m
+    networks:
+      - proxy
+  backend:
+    image: duboc/cdbackend:1.1
+    ports:
+      - "9090:9090"
+    environment:
+      WF_PROXY: wavefront_proxy:2878
+    networks:
+      - proxy
+  frontend:
+    image: duboc/cdfrontend:1.2
+    ports:
+      - "80:80"
+    networks:
+      - proxy
+    volumes:
+      - nginx_logs:/var/log/nginx
+  telegraf:
+    image: telegraf:1.8.3
+    volumes:
+      - ./telegraph/telegraf.conf:/etc/telegraf/telegraf.conf:ro
+      - nginx_logs:/var/log/nginx:ro
+    networks:
+      - proxy
+
+networks:
+  proxy:
+
+volumes:
+  nginx_logs:

--- a/telegraph/telegraf.conf
+++ b/telegraph/telegraf.conf
@@ -1,5 +1,5 @@
 [[inputs.nginx]]
-  urls = ["http://ec2-54-89-29-170.compute-1.amazonaws.com:81/basic_status"]
+  urls = ["http://frontend:81/basic_status"]
 
 [[inputs.tail]]
    files = ["/var/log/nginx/access.log"]
@@ -24,7 +24,7 @@
      port = "81"
 
 [[outputs.wavefront]]
-  host = "ec2-54-89-29-170.compute-1.amazonaws.com"
+  host = "wavefront_proxy"
   port = 2878
   metric_separator = "."
   source_override = ["hostname", "agent_host", "node_host"]


### PR DESCRIPTION
Inclusao do docker compose.
Precisa apenas ter as variaves de ambiente WAVEFRONT_URL e WAVEFRONT_TOKEN

Depois um docker-compose up sobe toda a stack
